### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ to use Node to serve their app.
 The seed app shows how to wire together Angular client-side components with Express on the server and have OAuth setup, so that you dont have to worry about
 authentication of your user.
 
-##Note :
+## Note :
 
 Unlike _Angular Express Seed_ this project uses html itself as the templating engine which I personally find more comfortable.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
